### PR TITLE
Add CPU superclass

### DIFF
--- a/src/br/edu/insper/desagil/elesys/CPU.java
+++ b/src/br/edu/insper/desagil/elesys/CPU.java
@@ -1,0 +1,5 @@
+package br.edu.insper.desagil.elesys;
+
+public abstract class CPU {
+	public abstract double getPower();
+}

--- a/src/br/edu/insper/desagil/elesys/Computer.java
+++ b/src/br/edu/insper/desagil/elesys/Computer.java
@@ -4,29 +4,20 @@ import java.util.ArrayList;
 import java.util.List;
 
 public class Computer {
-	private List<SingleCoreCPU> singleProcs;
-	private List<MultiCoreCPU> multiProcs;
+	private List<CPU> procs;
 
 	public Computer() {
-		this.singleProcs = new ArrayList<>();
-		this.multiProcs = new ArrayList<>();
+		this.procs = new ArrayList<>();
 	}
 
-	public void add(SingleCoreCPU proc) {
-		this.singleProcs.add(proc);
-	}
-
-	public void add(MultiCoreCPU proc) {
-		this.multiProcs.add(proc);
+	public void add(CPU proc) {
+		this.procs.add(proc);
 	}
 
 	public double getProcPower() {
 		double s = 0;
-		for (SingleCoreCPU singleProc: this.singleProcs) {
-			s += singleProc.getPower();
-		}
-		for (MultiCoreCPU multiProc: this.multiProcs) {
-			s += multiProc.getPower();
+		for (CPU proc: this.procs) {
+			s += proc.getPower();
 		}
 		return s;
 	}

--- a/src/br/edu/insper/desagil/elesys/MultiCoreCPU.java
+++ b/src/br/edu/insper/desagil/elesys/MultiCoreCPU.java
@@ -2,7 +2,7 @@ package br.edu.insper.desagil.elesys;
 
 import java.util.List;
 
-public class MultiCoreCPU {
+public class MultiCoreCPU extends CPU {
 	private List<SingleCoreCPU> cores;
 	private double overhead;
 
@@ -15,6 +15,7 @@ public class MultiCoreCPU {
 		return this.cores;
 	}
 
+	@Override
 	public double getPower() {
 		double power = 0;
 		for (SingleCoreCPU core: this.cores) {

--- a/src/br/edu/insper/desagil/elesys/SingleCoreCPU.java
+++ b/src/br/edu/insper/desagil/elesys/SingleCoreCPU.java
@@ -1,12 +1,13 @@
 package br.edu.insper.desagil.elesys;
 
-public class SingleCoreCPU {
+public class SingleCoreCPU extends CPU {
 	private double power;
 
 	public SingleCoreCPU(double power) {
 		this.power = power;
 	}
 
+	@Override
 	public double getPower() {
 		return power;
 	}


### PR DESCRIPTION
Esta modificação adiciona uma superclasse CPU. Essa superclasse é uma abstração do conceito de processador, independente dos detalhes de implementação usados por SingleCoreCPU e MultiCoreCPU.

Essa abstração permite que as duas listas de processadores do objeto Computer sejam substituídas por uma única lista, reduzindo a repetição de código principalmente no método getProcPower.

Além disso, deixa o código mais preparado para outros tipos de CPU que possam ser adicionados no futuro.